### PR TITLE
Fix dbt deprecation around test

### DIFF
--- a/models/schema.yml
+++ b/models/schema.yml
@@ -55,7 +55,8 @@ models:
         description: '{{ doc("orders_status") }}'
         tests:
           - accepted_values:
-              values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
+              arguments:
+                values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
 
       - name: amount
         description: Total amount (AUD) of the order

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -44,8 +44,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('customers')
-              field: customer_id
+              arguments:
+                to: ref('customers')
+                field: customer_id
 
       - name: order_date
         description: Date (UTC) that the order was placed

--- a/models/staging/schema.yml
+++ b/models/staging/schema.yml
@@ -17,7 +17,8 @@ models:
       - name: status
         tests:
           - accepted_values:
-              values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
+              arguments:
+                values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
 
   - name: stg_payments
     columns:
@@ -28,4 +29,5 @@ models:
       - name: payment_method
         tests:
           - accepted_values:
-              values: ['credit_card', 'coupon', 'bank_transfer', 'gift_card']
+              arguments:
+                values: ['credit_card', 'coupon', 'bank_transfer', 'gift_card']


### PR DESCRIPTION
Following some [depreciation introduced in dbt 1.10](https://docs.getdbt.com/reference/deprecations#argumentspropertyingenerictestdeprecation), some flow executions end up in WARNING state. As I understand it will error in next version of dbt.

This PR fix the issue; tested on postgres-ee-preview with this branch:

```yaml
id: dbt-git-docker-duckdb
namespace: sanitychecks.blueprints
tasks:
  - id: dbt
    type: io.kestra.plugin.core.flow.WorkingDirectory
    tasks:
      - id: clone_repository
        type: io.kestra.plugin.git.Clone
        url: https://github.com/kestra-io/dbt-demo
        branch: fix/dbt_version
      - id: dbt_core
        type: io.kestra.plugin.dbt.cli.DbtCLI
        taskRunner:
          type: io.kestra.plugin.scripts.runner.docker.Docker
        containerImage: ghcr.io/kestra-io/dbt-duckdb:latest
        inputFiles:
          packages.yml: |
            packages:
              - package: brooklyn-data/dbt_artifacts
                version: 2.9.3
        profiles: "jaffle_shop:\n  outputs:\n    dev:\n      type: duckdb\n      path: \":memory:\"\n      extensions: \n        - parquet\n      fixed_retries: 1\n      threads: 16\n      timeout_seconds: 300\n  target: dev\n"
        commands:
          - dbt deps
          - dbt build
```

<img width="2286" height="1580" alt="image" src="https://github.com/user-attachments/assets/2b603206-9d1a-46e8-b79e-8c6decc41402" />
